### PR TITLE
Fix for python 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ MANIFEST
 env*
 build/
 dist/
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ env*
 build/
 dist/
 .venv/
+fastlz.egg-info/

--- a/fastlz.c
+++ b/fastlz.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "fastlz/fastlz.h"
 
@@ -16,7 +17,7 @@ compress(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *result;
     const char *input;
     char *output;
-    int level = 0, input_len, output_len;
+    Py_ssize_t level = 0, input_len, output_len;
 
     static char *arglist[] = {"string", "level", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s#|i", arglist, &input,
@@ -62,9 +63,9 @@ decompress(PyObject *self, PyObject *args)
 {
     PyObject *result;
     const char *input;
-    int input_len;
+    Py_ssize_t input_len;
     char *output;
-    uint32_t output_len, decompressed_len;
+    Py_ssize_t output_len, decompressed_len;
 
     if (!PyArg_ParseTuple(args, "s#", &input, &input_len))
         return NULL;

--- a/fastlz/fastlz.c
+++ b/fastlz/fastlz.c
@@ -1,9 +1,6 @@
-/*  
-  FastLZ - lightning-fast lossless compression library
-
-  Copyright (C) 2007 Ariya Hidayat (ariya@kde.org)
-  Copyright (C) 2006 Ariya Hidayat (ariya@kde.org)
-  Copyright (C) 2005 Ariya Hidayat (ariya@kde.org)
+/*
+  FastLZ - Byte-aligned LZ77 compression library
+  Copyright (C) 2005-2020 Ariya Hidayat <ariya.hidayat@gmail.com>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -24,239 +21,123 @@
   THE SOFTWARE.
 */
 
-#if !defined(FASTLZ__COMPRESSOR) && !defined(FASTLZ_DECOMPRESSOR)
+#include "fastlz.h"
+
+#include <stdint.h>
 
 /*
  * Always check for bound when decompressing.
  * Generally it is best to leave it defined.
  */
 #define FASTLZ_SAFE
+#if defined(FASTLZ_USE_SAFE_DECOMPRESSOR) && (FASTLZ_USE_SAFE_DECOMPRESSOR == 0)
+#undef FASTLZ_SAFE
+#endif
 
 /*
  * Give hints to the compiler for branch prediction optimization.
  */
-#if defined(__GNUC__) && (__GNUC__ > 2)
-#define FASTLZ_EXPECT_CONDITIONAL(c)    (__builtin_expect((c), 1))
-#define FASTLZ_UNEXPECT_CONDITIONAL(c)  (__builtin_expect((c), 0))
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 2))
+#define FASTLZ_LIKELY(c) (__builtin_expect(!!(c), 1))
+#define FASTLZ_UNLIKELY(c) (__builtin_expect(!!(c), 0))
 #else
-#define FASTLZ_EXPECT_CONDITIONAL(c)    (c)
-#define FASTLZ_UNEXPECT_CONDITIONAL(c)  (c)
+#define FASTLZ_LIKELY(c) (c)
+#define FASTLZ_UNLIKELY(c) (c)
 #endif
 
-/*
- * Use inlined functions for supported systems.
- */
-#if defined(__GNUC__) || defined(__DMC__) || defined(__POCC__) || defined(__WATCOMC__) || defined(__SUNPRO_C)
-#define FASTLZ_INLINE inline
-#elif defined(__BORLANDC__) || defined(_MSC_VER) || defined(__LCC__)
-#define FASTLZ_INLINE __inline
-#else 
-#define FASTLZ_INLINE
-#endif
-
-/*
- * Prevent accessing more than 8-bit at once, except on x86 architectures.
- */
-#if !defined(FASTLZ_STRICT_ALIGN)
-#define FASTLZ_STRICT_ALIGN
-#if defined(__i386__) || defined(__386)  /* GNU C, Sun Studio */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(__i486__) || defined(__i586__) || defined(__i686__) /* GNU C */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(_M_IX86) /* Intel, MSVC */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(__386)
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(_X86_) /* MinGW */
-#undef FASTLZ_STRICT_ALIGN
-#elif defined(__I86__) /* Digital Mars */
-#undef FASTLZ_STRICT_ALIGN
-#endif
-#endif
-
-/*
- * FIXME: use preprocessor magic to set this on different platforms!
- */
-typedef unsigned char  flzuint8;
-typedef unsigned short flzuint16;
-typedef unsigned int   flzuint32;
-
-/* prototypes */
-int fastlz_compress(const void* input, int length, void* output);
-int fastlz_compress_level(int level, const void* input, int length, void* output);
-int fastlz_decompress(const void* input, int length, void* output, int maxout);
-
-#define MAX_COPY       32
-#define MAX_LEN       264  /* 256 + 8 */
-#define MAX_DISTANCE 8192
-
-#if !defined(FASTLZ_STRICT_ALIGN)
-#define FASTLZ_READU16(p) *((const flzuint16*)(p)) 
+#if defined(FASTLZ_SAFE)
+#define FASTLZ_BOUND_CHECK(cond) \
+  if (FASTLZ_UNLIKELY(!(cond)))  \
+    return 0;
 #else
-#define FASTLZ_READU16(p) ((p)[0] | (p)[1]<<8)
+#define FASTLZ_BOUND_CHECK(cond) \
+  do                             \
+  {                              \
+  } while (0)
 #endif
 
-#define HASH_LOG  13
-#define HASH_SIZE (1<< HASH_LOG)
-#define HASH_MASK  (HASH_SIZE-1)
-#define HASH_FUNCTION(v,p) { v = FASTLZ_READU16(p); v ^= FASTLZ_READU16(p+1)^(v>>(16-HASH_LOG));v &= HASH_MASK; }
+#define MAX_COPY 32
+#define MAX_LEN 264 /* 256 + 8 */
+#define MAX_L1_DISTANCE 8192
+#define MAX_L2_DISTANCE 8191
+#define MAX_FARDISTANCE (65535 + MAX_L2_DISTANCE - 1)
 
-#undef FASTLZ_LEVEL
-#define FASTLZ_LEVEL 1
+#define FASTLZ_READU16(p) ((p)[0] | (p)[1] << 8)
 
-#undef FASTLZ_COMPRESSOR
-#undef FASTLZ_DECOMPRESSOR
-#define FASTLZ_COMPRESSOR fastlz1_compress
-#define FASTLZ_DECOMPRESSOR fastlz1_decompress
-static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* output);
-static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void* output, int maxout);
-#include "fastlz.c"
+#define HASH_LOG 13
+#define HASH_SIZE (1 << HASH_LOG)
+#define HASH_MASK (HASH_SIZE - 1)
+#define HASH_FUNCTION(v, p)                              \
+  {                                                      \
+    v = FASTLZ_READU16(p);                               \
+    v ^= FASTLZ_READU16(p + 1) ^ (v >> (16 - HASH_LOG)); \
+    v &= HASH_MASK;                                      \
+  }
 
-#undef FASTLZ_LEVEL
-#define FASTLZ_LEVEL 2
-
-#undef MAX_DISTANCE
-#define MAX_DISTANCE 8191
-#define MAX_FARDISTANCE (65535+MAX_DISTANCE-1)
-
-#undef FASTLZ_COMPRESSOR
-#undef FASTLZ_DECOMPRESSOR
-#define FASTLZ_COMPRESSOR fastlz2_compress
-#define FASTLZ_DECOMPRESSOR fastlz2_decompress
-static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* output);
-static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void* output, int maxout);
-#include "fastlz.c"
-
-int fastlz_compress(const void* input, int length, void* output)
+int fastlz1_compress(const void *input, int length, void *output)
 {
-  /* for short block, choose fastlz1 */
-  if(length < 65536)
-    return fastlz1_compress(input, length, output);
+  const uint8_t *ip = (const uint8_t *)input;
+  const uint8_t *ip_bound = ip + length - 2;
+  const uint8_t *ip_limit = ip + length - 12 - 1;
+  uint8_t *op = (uint8_t *)output;
 
-  /* else... */
-  return fastlz2_compress(input, length, output);
-}
+  const uint8_t *htab[HASH_SIZE];
+  uint32_t hval;
 
-int fastlz_decompress(const void* input, int length, void* output, int maxout)
-{
-  /* magic identifier for compression level */
-  int level = ((*(const flzuint8*)input) >> 5) + 1;
-
-  if(level == 1)
-    return fastlz1_decompress(input, length, output, maxout);
-  if(level == 2)
-    return fastlz2_decompress(input, length, output, maxout);
-
-  /* unknown level, trigger error */
-  return 0;
-}
-
-int fastlz_compress_level(int level, const void* input, int length, void* output)
-{
-  if(level == 1)
-    return fastlz1_compress(input, length, output);
-  if(level == 2)
-    return fastlz2_compress(input, length, output);
-
-  return 0;
-}
-
-#else /* !defined(FASTLZ_COMPRESSOR) && !defined(FASTLZ_DECOMPRESSOR) */
-
-static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* output)
-{
-  const flzuint8* ip = (const flzuint8*) input;
-  const flzuint8* ip_bound = ip + length - 2;
-  const flzuint8* ip_limit = ip + length - 12;
-  flzuint8* op = (flzuint8*) output;
-
-  const flzuint8* htab[HASH_SIZE];
-  const flzuint8** hslot;
-  flzuint32 hval;
-
-  flzuint32 copy;
+  uint32_t copy;
 
   /* sanity check */
-  if(FASTLZ_UNEXPECT_CONDITIONAL(length < 4))
+  if (FASTLZ_UNLIKELY(length < 4))
   {
-    if(length)
+    if (length)
     {
       /* create literal copy only */
-      *op++ = length-1;
+      *op++ = length - 1;
       ip_bound++;
-      while(ip <= ip_bound)
+      while (ip <= ip_bound)
         *op++ = *ip++;
-      return length+1;
+      return length + 1;
     }
     else
       return 0;
   }
 
   /* initializes hash table */
-  for (hslot = htab; hslot < htab + HASH_SIZE; hslot++)
-    *hslot = ip;
+  for (hval = 0; hval < HASH_SIZE; ++hval)
+    htab[hval] = ip;
 
   /* we start with literal copy */
   copy = 2;
-  *op++ = MAX_COPY-1;
+  *op++ = MAX_COPY - 1;
   *op++ = *ip++;
   *op++ = *ip++;
 
   /* main loop */
-  while(FASTLZ_EXPECT_CONDITIONAL(ip < ip_limit))
+  while (FASTLZ_LIKELY(ip < ip_limit))
   {
-    const flzuint8* ref;
-    flzuint32 distance;
+    const uint8_t *ref;
+    uint32_t distance;
 
     /* minimum match length */
-    flzuint32 len = 3;
+    uint32_t len = 3;
 
     /* comparison starting-point */
-    const flzuint8* anchor = ip;
-
-    /* check for a run */
-#if FASTLZ_LEVEL==2
-    if(ip[0] == ip[-1] && FASTLZ_READU16(ip-1)==FASTLZ_READU16(ip+1))
-    {
-      distance = 1;
-      ip += 3;
-      ref = anchor - 1 + 3;
-      goto match;
-    }
-#endif
+    const uint8_t *anchor = ip;
 
     /* find potential match */
-    HASH_FUNCTION(hval,ip);
-    hslot = htab + hval;
+    HASH_FUNCTION(hval, ip);
     ref = htab[hval];
+
+    /* update hash table */
+    htab[hval] = anchor;
 
     /* calculate distance to the match */
     distance = anchor - ref;
 
-    /* update hash table */
-    *hslot = anchor;
-
     /* is this a match? check the first 3 bytes */
-    if(distance==0 || 
-#if FASTLZ_LEVEL==1
-    (distance >= MAX_DISTANCE) ||
-#else
-    (distance >= MAX_FARDISTANCE) ||
-#endif
-    *ref++ != *ip++ || *ref++!=*ip++ || *ref++!=*ip++)
+    if (distance == 0 || (distance >= MAX_L1_DISTANCE) || *ref++ != *ip++ ||
+        *ref++ != *ip++ || *ref++ != *ip++)
       goto literal;
-
-#if FASTLZ_LEVEL==2
-    /* far, needs at least 5-byte match */
-    if(distance >= MAX_DISTANCE)
-    {
-      if(*ip++ != *ref++ || *ip++!= *ref++) 
-        goto literal;
-      len += 2;
-    }
-    
-    match:
-#endif
 
     /* last matched byte */
     ip = anchor + len;
@@ -264,34 +145,45 @@ static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* 
     /* distance is biased */
     distance--;
 
-    if(!distance)
+    if (!distance)
     {
       /* zero distance means a run */
-      flzuint8 x = ip[-1];
-      while(ip < ip_bound)
-        if(*ref++ != x) break; else ip++;
+      uint8_t x = ip[-1];
+      while (ip < ip_bound)
+        if (*ref++ != x)
+          break;
+        else
+          ip++;
     }
     else
-    for(;;)
-    {
-      /* safe because the outer check against ip limit */
-      if(*ref++ != *ip++) break;
-      if(*ref++ != *ip++) break;
-      if(*ref++ != *ip++) break;
-      if(*ref++ != *ip++) break;
-      if(*ref++ != *ip++) break;
-      if(*ref++ != *ip++) break;
-      if(*ref++ != *ip++) break;
-      if(*ref++ != *ip++) break;
-      while(ip < ip_bound)
-        if(*ref++ != *ip++) break;
-      break;
-    }
+      for (;;)
+      {
+        /* safe because the outer check against ip limit */
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        while (ip < ip_bound)
+          if (*ref++ != *ip++)
+            break;
+        break;
+      }
 
     /* if we have copied something, adjust the copy count */
-    if(copy)
-      /* copy is biased, '0' means 1 byte copy */
-      *(op-copy-1) = copy-1;
+    if (copy) /* copy is biased, '0' means 1 byte copy */
+      *(op - copy - 1) = copy - 1;
     else
       /* back, to overwrite the copy count */
       op--;
@@ -304,58 +196,16 @@ static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* 
     len = ip - anchor;
 
     /* encode the match */
-#if FASTLZ_LEVEL==2
-    if(distance < MAX_DISTANCE)
-    {
-      if(len < 7)
-      {
-        *op++ = (len << 5) + (distance >> 8);
-        *op++ = (distance & 255);
-      }
-      else
+    if (FASTLZ_UNLIKELY(len > MAX_LEN - 2))
+      while (len > MAX_LEN - 2)
       {
         *op++ = (7 << 5) + (distance >> 8);
-        for(len-=7; len >= 255; len-= 255)
-          *op++ = 255;
-        *op++ = len;
+        *op++ = MAX_LEN - 2 - 7 - 2;
         *op++ = (distance & 255);
-      }
-    }
-    else
-    {
-      /* far away, but not yet in the another galaxy... */
-      if(len < 7)
-      {
-        distance -= MAX_DISTANCE;
-        *op++ = (len << 5) + 31;
-        *op++ = 255;
-        *op++ = distance >> 8;
-        *op++ = distance & 255;
-      }
-      else
-      {
-        distance -= MAX_DISTANCE;
-        *op++ = (7 << 5) + 31;
-        for(len-=7; len >= 255; len-= 255)
-          *op++ = 255;
-        *op++ = len;
-        *op++ = 255;
-        *op++ = distance >> 8;
-        *op++ = distance & 255;
-      }
-    }
-#else
-
-    if(FASTLZ_UNEXPECT_CONDITIONAL(len > MAX_LEN-2))
-      while(len > MAX_LEN-2)
-      {
-        *op++ = (7 << 5) + (distance >> 8);
-        *op++ = MAX_LEN - 2 - 7 -2; 
-        *op++ = (distance & 255);
-        len -= MAX_LEN-2;
+        len -= MAX_LEN - 2;
       }
 
-    if(len < 7)
+    if (len < 7)
     {
       *op++ = (len << 5) + (distance >> 8);
       *op++ = (distance & 255);
@@ -366,186 +216,474 @@ static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* 
       *op++ = len - 7;
       *op++ = (distance & 255);
     }
-#endif
 
     /* update the hash at match boundary */
-    HASH_FUNCTION(hval,ip);
+    HASH_FUNCTION(hval, ip);
     htab[hval] = ip++;
-    HASH_FUNCTION(hval,ip);
+    HASH_FUNCTION(hval, ip);
     htab[hval] = ip++;
 
     /* assuming literal copy */
-    *op++ = MAX_COPY-1;
+    *op++ = MAX_COPY - 1;
 
     continue;
 
-    literal:
-      *op++ = *anchor++;
-      ip = anchor;
-      copy++;
-      if(FASTLZ_UNEXPECT_CONDITIONAL(copy == MAX_COPY))
-      {
-        copy = 0;
-        *op++ = MAX_COPY-1;
-      }
+  literal:
+    *op++ = *anchor++;
+    ip = anchor;
+    copy++;
+    if (FASTLZ_UNLIKELY(copy == MAX_COPY))
+    {
+      copy = 0;
+      *op++ = MAX_COPY - 1;
+    }
   }
 
   /* left-over as literal copy */
   ip_bound++;
-  while(ip <= ip_bound)
+  while (ip <= ip_bound)
   {
     *op++ = *ip++;
     copy++;
-    if(copy == MAX_COPY)
+    if (copy == MAX_COPY)
     {
       copy = 0;
-      *op++ = MAX_COPY-1;
+      *op++ = MAX_COPY - 1;
     }
   }
 
   /* if we have copied something, adjust the copy length */
-  if(copy)
-    *(op-copy-1) = copy-1;
+  if (copy)
+    *(op - copy - 1) = copy - 1;
   else
     op--;
 
-#if FASTLZ_LEVEL==2
-  /* marker for fastlz2 */
-  *(flzuint8*)output |= (1 << 5);
-#endif
-
-  return op - (flzuint8*)output;
+  return op - (uint8_t *)output;
 }
 
-static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void* output, int maxout)
-{
-  const flzuint8* ip = (const flzuint8*) input;
-  const flzuint8* ip_limit  = ip + length;
-  flzuint8* op = (flzuint8*) output;
-  flzuint8* op_limit = op + maxout;
-  flzuint32 ctrl = (*ip++) & 31;
-  int loop = 1;
+#if defined(FASTLZ_USE_MEMMOVE) && (FASTLZ_USE_MEMMOVE == 0)
 
+static void fastlz_memmove(uint8_t *dest, const uint8_t *src, uint32_t count)
+{
   do
   {
-    const flzuint8* ref = op;
-    flzuint32 len = ctrl >> 5;
-    flzuint32 ofs = (ctrl & 31) << 8;
+    *dest++ = *src++;
+  } while (--count);
+}
 
-    if(ctrl >= 32)
+static void fastlz_memcpy(uint8_t *dest, const uint8_t *src, uint32_t count)
+{
+  return fastlz_memmove(dest, src, count);
+}
+
+#else
+
+#include <string.h>
+
+static void fastlz_memmove(uint8_t *dest, const uint8_t *src, uint32_t count)
+{
+  if ((count > 4) && (dest >= src + count))
+  {
+    memmove(dest, src, count);
+  }
+  else
+  {
+    switch (count)
     {
-#if FASTLZ_LEVEL==2
-      flzuint8 code;
+    default:
+      do
+      {
+        *dest++ = *src++;
+      } while (--count);
+      break;
+    case 3:
+      *dest++ = *src++;
+    case 2:
+      *dest++ = *src++;
+    case 1:
+      *dest++ = *src++;
+    case 0:
+      break;
+    }
+  }
+}
+
+static void fastlz_memcpy(uint8_t *dest, const uint8_t *src, uint32_t count)
+{
+  memcpy(dest, src, count);
+}
+
 #endif
-      len--;
-      ref -= ofs;
-      if (len == 7-1)
-#if FASTLZ_LEVEL==1
+
+int fastlz1_decompress(const void *input, int length, void *output,
+                       int maxout)
+{
+  const uint8_t *ip = (const uint8_t *)input;
+  const uint8_t *ip_limit = ip + length;
+  const uint8_t *ip_bound = ip_limit - 2;
+  uint8_t *op = (uint8_t *)output;
+  uint8_t *op_limit = op + maxout;
+  uint32_t ctrl = (*ip++) & 31;
+
+  while (1)
+  {
+    if (ctrl >= 32)
+    {
+      uint32_t len = (ctrl >> 5) - 1;
+      uint32_t ofs = (ctrl & 31) << 8;
+      const uint8_t *ref = op - ofs - 1;
+      if (len == 7 - 1)
+      {
+        FASTLZ_BOUND_CHECK(ip <= ip_bound);
         len += *ip++;
+      }
       ref -= *ip++;
-#else
-        do
-        {
-          code = *ip++;
-          len += code;
-        } while (code==255);
-      code = *ip++;
-      ref -= code;
-
-      /* match from 16-bit distance */
-      if(FASTLZ_UNEXPECT_CONDITIONAL(code==255))
-      if(FASTLZ_EXPECT_CONDITIONAL(ofs==(31 << 8)))
-      {
-        ofs = (*ip++) << 8;
-        ofs += *ip++;
-        ref = op - ofs - MAX_DISTANCE;
-      }
-#endif
-      
-#ifdef FASTLZ_SAFE
-      if (FASTLZ_UNEXPECT_CONDITIONAL(op + len + 3 > op_limit))
-        return 0;
-
-      if (FASTLZ_UNEXPECT_CONDITIONAL(ref-1 < (flzuint8 *)output))
-        return 0;
-#endif
-
-      if(FASTLZ_EXPECT_CONDITIONAL(ip < ip_limit))
-        ctrl = *ip++;
-      else
-        loop = 0;
-
-      if(ref == op)
-      {
-        /* optimize copy for a run */
-        flzuint8 b = ref[-1];
-        *op++ = b;
-        *op++ = b;
-        *op++ = b;
-        for(; len; --len)
-          *op++ = b;
-      }
-      else
-      {
-#if !defined(FASTLZ_STRICT_ALIGN)
-        const flzuint16* p;
-        flzuint16* q;
-#endif
-        /* copy from reference */
-        ref--;
-        *op++ = *ref++;
-        *op++ = *ref++;
-        *op++ = *ref++;
-
-#if !defined(FASTLZ_STRICT_ALIGN)
-        /* copy a byte, so that now it's word aligned */
-        if(len & 1)
-        {
-          *op++ = *ref++;
-          len--;
-        }
-
-        /* copy 16-bit at once */
-        q = (flzuint16*) op;
-        op += len;
-        p = (const flzuint16*) ref;
-        for(len>>=1; len > 4; len-=4)
-        {
-          *q++ = *p++;
-          *q++ = *p++;
-          *q++ = *p++;
-          *q++ = *p++;
-        }
-        for(; len; --len)
-          *q++ = *p++;
-#else
-        for(; len; --len)
-          *op++ = *ref++;
-#endif
-      }
+      len += 3;
+      FASTLZ_BOUND_CHECK(op + len <= op_limit);
+      FASTLZ_BOUND_CHECK(ref >= (uint8_t *)output);
+      fastlz_memmove(op, ref, len);
+      op += len;
     }
     else
     {
       ctrl++;
-#ifdef FASTLZ_SAFE
-      if (FASTLZ_UNEXPECT_CONDITIONAL(op + ctrl > op_limit))
-        return 0;
-      if (FASTLZ_UNEXPECT_CONDITIONAL(ip + ctrl > ip_limit))
-        return 0;
-#endif
-
-      *op++ = *ip++; 
-      for(--ctrl; ctrl; ctrl--)
-        *op++ = *ip++;
-
-      loop = FASTLZ_EXPECT_CONDITIONAL(ip < ip_limit);
-      if(loop)
-        ctrl = *ip++;
+      FASTLZ_BOUND_CHECK(op + ctrl <= op_limit);
+      FASTLZ_BOUND_CHECK(ip + ctrl <= ip_limit);
+      fastlz_memcpy(op, ip, ctrl);
+      ip += ctrl;
+      op += ctrl;
     }
-  }
-  while(FASTLZ_EXPECT_CONDITIONAL(loop));
 
-  return op - (flzuint8*)output;
+    if (FASTLZ_UNLIKELY(ip > ip_bound))
+      break;
+    ctrl = *ip++;
+  }
+
+  return op - (uint8_t *)output;
 }
 
-#endif /* !defined(FASTLZ_COMPRESSOR) && !defined(FASTLZ_DECOMPRESSOR) */
+int fastlz2_compress(const void *input, int length, void *output)
+{
+  const uint8_t *ip = (const uint8_t *)input;
+  const uint8_t *ip_bound = ip + length - 2;
+  const uint8_t *ip_limit = ip + length - 12 - 1;
+  uint8_t *op = (uint8_t *)output;
+
+  const uint8_t *htab[HASH_SIZE];
+  uint32_t hval;
+
+  uint32_t copy;
+
+  /* sanity check */
+  if (FASTLZ_UNLIKELY(length < 4))
+  {
+    if (length)
+    {
+      /* create literal copy only */
+      *op++ = length - 1;
+      ip_bound++;
+      while (ip <= ip_bound)
+        *op++ = *ip++;
+      return length + 1;
+    }
+    else
+      return 0;
+  }
+
+  /* initializes hash table */
+  for (hval = 0; hval < HASH_SIZE; ++hval)
+    htab[hval] = ip;
+
+  /* we start with literal copy */
+  copy = 2;
+  *op++ = MAX_COPY - 1;
+  *op++ = *ip++;
+  *op++ = *ip++;
+
+  /* main loop */
+  while (FASTLZ_LIKELY(ip < ip_limit))
+  {
+    const uint8_t *ref;
+    uint32_t distance;
+
+    /* minimum match length */
+    uint32_t len = 3;
+
+    /* comparison starting-point */
+    const uint8_t *anchor = ip;
+
+    /* check for a run */
+    if (ip[0] == ip[-1] && ip[0] == ip[1] && ip[1] == ip[2])
+    {
+      distance = 1;
+      ip += 3;
+      ref = anchor - 1 + 3;
+      goto match;
+    }
+
+    /* find potential match */
+    HASH_FUNCTION(hval, ip);
+    ref = htab[hval];
+
+    /* update hash table */
+    htab[hval] = anchor;
+
+    /* calculate distance to the match */
+    distance = anchor - ref;
+
+    /* is this a match? check the first 3 bytes */
+    if (distance == 0 || (distance >= MAX_FARDISTANCE) || *ref++ != *ip++ ||
+        *ref++ != *ip++ || *ref++ != *ip++)
+      goto literal;
+
+    /* far, needs at least 5-byte match */
+    if (distance >= MAX_L2_DISTANCE)
+    {
+      if (*ip++ != *ref++ || *ip++ != *ref++)
+        goto literal;
+      len += 2;
+    }
+
+  match:
+
+    /* last matched byte */
+    ip = anchor + len;
+
+    /* distance is biased */
+    distance--;
+
+    if (!distance)
+    {
+      /* zero distance means a run */
+      uint8_t x = ip[-1];
+      while (ip < ip_bound)
+        if (*ref++ != x)
+          break;
+        else
+          ip++;
+    }
+    else
+      for (;;)
+      {
+        /* safe because the outer check against ip limit */
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        if (*ref++ != *ip++)
+          break;
+        while (ip < ip_bound)
+          if (*ref++ != *ip++)
+            break;
+        break;
+      }
+
+    /* if we have copied something, adjust the copy count */
+    if (copy) /* copy is biased, '0' means 1 byte copy */
+      *(op - copy - 1) = copy - 1;
+    else
+      /* back, to overwrite the copy count */
+      op--;
+
+    /* reset literal counter */
+    copy = 0;
+
+    /* length is biased, '1' means a match of 3 bytes */
+    ip -= 3;
+    len = ip - anchor;
+
+    /* encode the match */
+    if (distance < MAX_L2_DISTANCE)
+    {
+      if (len < 7)
+      {
+        *op++ = (len << 5) + (distance >> 8);
+        *op++ = (distance & 255);
+      }
+      else
+      {
+        *op++ = (7 << 5) + (distance >> 8);
+        for (len -= 7; len >= 255; len -= 255)
+          *op++ = 255;
+        *op++ = len;
+        *op++ = (distance & 255);
+      }
+    }
+    else
+    {
+      /* far away, but not yet in the another galaxy... */
+      if (len < 7)
+      {
+        distance -= MAX_L2_DISTANCE;
+        *op++ = (len << 5) + 31;
+        *op++ = 255;
+        *op++ = distance >> 8;
+        *op++ = distance & 255;
+      }
+      else
+      {
+        distance -= MAX_L2_DISTANCE;
+        *op++ = (7 << 5) + 31;
+        for (len -= 7; len >= 255; len -= 255)
+          *op++ = 255;
+        *op++ = len;
+        *op++ = 255;
+        *op++ = distance >> 8;
+        *op++ = distance & 255;
+      }
+    }
+
+    /* update the hash at match boundary */
+    HASH_FUNCTION(hval, ip);
+    htab[hval] = ip++;
+    HASH_FUNCTION(hval, ip);
+    htab[hval] = ip++;
+
+    /* assuming literal copy */
+    *op++ = MAX_COPY - 1;
+
+    continue;
+
+  literal:
+    *op++ = *anchor++;
+    ip = anchor;
+    copy++;
+    if (FASTLZ_UNLIKELY(copy == MAX_COPY))
+    {
+      copy = 0;
+      *op++ = MAX_COPY - 1;
+    }
+  }
+
+  /* left-over as literal copy */
+  ip_bound++;
+  while (ip <= ip_bound)
+  {
+    *op++ = *ip++;
+    copy++;
+    if (copy == MAX_COPY)
+    {
+      copy = 0;
+      *op++ = MAX_COPY - 1;
+    }
+  }
+
+  /* if we have copied something, adjust the copy length */
+  if (copy)
+    *(op - copy - 1) = copy - 1;
+  else
+    op--;
+
+  /* marker for fastlz2 */
+  *(uint8_t *)output |= (1 << 5);
+
+  return op - (uint8_t *)output;
+}
+
+int fastlz2_decompress(const void *input, int length, void *output,
+                       int maxout)
+{
+  const uint8_t *ip = (const uint8_t *)input;
+  const uint8_t *ip_limit = ip + length;
+  const uint8_t *ip_bound = ip_limit - 2;
+  uint8_t *op = (uint8_t *)output;
+  uint8_t *op_limit = op + maxout;
+  uint32_t ctrl = (*ip++) & 31;
+
+  while (1)
+  {
+    if (ctrl >= 32)
+    {
+      uint32_t len = (ctrl >> 5) - 1;
+      uint32_t ofs = (ctrl & 31) << 8;
+      const uint8_t *ref = op - ofs - 1;
+
+      uint8_t code;
+      if (len == 7 - 1)
+        do
+        {
+          FASTLZ_BOUND_CHECK(ip <= ip_bound);
+          code = *ip++;
+          len += code;
+        } while (code == 255);
+      code = *ip++;
+      ref -= code;
+      len += 3;
+
+      /* match from 16-bit distance */
+      if (FASTLZ_UNLIKELY(code == 255))
+        if (FASTLZ_LIKELY(ofs == (31 << 8)))
+        {
+          FASTLZ_BOUND_CHECK(ip < ip_bound);
+          ofs = (*ip++) << 8;
+          ofs += *ip++;
+          ref = op - ofs - MAX_L2_DISTANCE - 1;
+        }
+
+      FASTLZ_BOUND_CHECK(op + len <= op_limit);
+      FASTLZ_BOUND_CHECK(ref >= (uint8_t *)output);
+      fastlz_memmove(op, ref, len);
+      op += len;
+    }
+    else
+    {
+      ctrl++;
+      FASTLZ_BOUND_CHECK(op + ctrl <= op_limit);
+      FASTLZ_BOUND_CHECK(ip + ctrl <= ip_limit);
+      fastlz_memcpy(op, ip, ctrl);
+      ip += ctrl;
+      op += ctrl;
+    }
+
+    if (FASTLZ_UNLIKELY(ip >= ip_limit))
+      break;
+    ctrl = *ip++;
+  }
+
+  return op - (uint8_t *)output;
+}
+
+int fastlz_compress(const void *input, int length, void *output)
+{
+  /* for short block, choose fastlz1 */
+  if (length < 65536)
+    return fastlz1_compress(input, length, output);
+
+  /* else... */
+  return fastlz2_compress(input, length, output);
+}
+
+int fastlz_decompress(const void *input, int length, void *output, int maxout)
+{
+  /* magic identifier for compression level */
+  int level = ((*(const uint8_t *)input) >> 5) + 1;
+
+  if (level == 1)
+    return fastlz1_decompress(input, length, output, maxout);
+  if (level == 2)
+    return fastlz2_decompress(input, length, output, maxout);
+
+  /* unknown level, trigger error */
+  return 0;
+}
+
+int fastlz_compress_level(int level, const void *input, int length,
+                          void *output)
+{
+  if (level == 1)
+    return fastlz1_compress(input, length, output);
+  if (level == 2)
+    return fastlz2_compress(input, length, output);
+
+  return 0;
+}

--- a/fastlz/fastlz.h
+++ b/fastlz/fastlz.h
@@ -1,9 +1,6 @@
-/*  
-  FastLZ - lightning-fast lossless compression library
-
-  Copyright (C) 2007 Ariya Hidayat (ariya@kde.org)
-  Copyright (C) 2006 Ariya Hidayat (ariya@kde.org)
-  Copyright (C) 2005 Ariya Hidayat (ariya@kde.org)
+/*
+  FastLZ - Byte-aligned LZ77 compression library
+  Copyright (C) 2005-2020 Ariya Hidayat <ariya.hidayat@gmail.com>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -27,73 +24,75 @@
 #ifndef FASTLZ_H
 #define FASTLZ_H
 
-#define FASTLZ_VERSION 0x000100
+#define FASTLZ_VERSION 0x000500
 
-#define FASTLZ_VERSION_MAJOR     0
-#define FASTLZ_VERSION_MINOR     0
-#define FASTLZ_VERSION_REVISION  0
+#define FASTLZ_VERSION_MAJOR 0
+#define FASTLZ_VERSION_MINOR 5
+#define FASTLZ_VERSION_REVISION 0
 
-#define FASTLZ_VERSION_STRING "0.1.0"
+#define FASTLZ_VERSION_STRING "0.5.0"
 
-#if defined (__cplusplus)
-extern "C" {
+#if defined(__cplusplus)
+extern "C"
+{
 #endif
 
-/**
-  Compress a block of data in the input buffer and returns the size of 
-  compressed block. The size of input buffer is specified by length. The 
-  minimum input buffer size is 16.
+  /**
+    Compress a block of data in the input buffer and returns the size of
+    compressed block. The size of input buffer is specified by length. The
+    minimum input buffer size is 16.
 
-  The output buffer must be at least 5% larger than the input buffer  
-  and can not be smaller than 66 bytes.
+    The output buffer must be at least 5% larger than the input buffer
+    and can not be smaller than 66 bytes.
 
-  If the input is not compressible, the return value might be larger than
-  length (input buffer size).
+    If the input is not compressible, the return value might be larger than
+    length (input buffer size).
 
-  The input buffer and the output buffer can not overlap.
-*/
+    The input buffer and the output buffer can not overlap.
 
-int fastlz_compress(const void* input, int length, void* output);
+    Compression level can be specified in parameter level. At the moment,
+    only level 1 and level 2 are supported.
+    Level 1 is the fastest compression and generally useful for short data.
+    Level 2 is slightly slower but it gives better compression ratio.
 
-/**
-  Decompress a block of compressed data and returns the size of the 
-  decompressed block. If error occurs, e.g. the compressed data is 
-  corrupted or the output buffer is not large enough, then 0 (zero) 
-  will be returned instead.
+    Note that the compressed data, regardless of the level, can always be
+    decompressed using the function fastlz_decompress below.
+  */
 
-  The input buffer and the output buffer can not overlap.
+  int fastlz_compress_level(int level, const void *input, int length,
+                            void *output);
 
-  Decompression is memory safe and guaranteed not to write the output buffer
-  more than what is specified in maxout.
- */
+  /**
+    Decompress a block of compressed data and returns the size of the
+    decompressed block. If error occurs, e.g. the compressed data is
+    corrupted or the output buffer is not large enough, then 0 (zero)
+    will be returned instead.
 
-int fastlz_decompress(const void* input, int length, void* output, int maxout); 
+    The input buffer and the output buffer can not overlap.
 
-/**
-  Compress a block of data in the input buffer and returns the size of 
-  compressed block. The size of input buffer is specified by length. The 
-  minimum input buffer size is 16.
+    Decompression is memory safe and guaranteed not to write the output buffer
+    more than what is specified in maxout.
 
-  The output buffer must be at least 5% larger than the input buffer  
-  and can not be smaller than 66 bytes.
+    Note that the decompression will always work, regardless of the
+    compression level specified in fastlz_compress_level above (when
+    producing the compressed block).
+   */
 
-  If the input is not compressible, the return value might be larger than
-  length (input buffer size).
+  int fastlz_decompress(const void *input, int length, void *output, int maxout);
 
-  The input buffer and the output buffer can not overlap.
+  /**
+    DEPRECATED.
 
-  Compression level can be specified in parameter level. At the moment, 
-  only level 1 and level 2 are supported.
-  Level 1 is the fastest compression and generally useful for short data.
-  Level 2 is slightly slower but it gives better compression ratio.
+    This is similar to fastlz_compress_level above, but with the level
+    automatically chosen.
 
-  Note that the compressed data, regardless of the level, can always be
-  decompressed using the function fastlz_decompress above.
-*/  
+    This function is deprecated and it will be completely removed in some future
+    version.
+  */
 
-int fastlz_compress_level(int level, const void* input, int length, void* output);
+  int fastlz_compress(const void *input, int length, void *output);
 
-#if defined (__cplusplus)
+#if defined(__cplusplus)
 }
 #endif
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from distutils.core import setup, Extension
 
 setup(
     name='fastlz',
+    python_requires='>=3.10.0',
     version='0.0.2',
     description='Python wrapper for FastLZ, a lightning-fast lossless '
                 'compression library.',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries',
         'Topic :: System :: Archiving :: Compression',
-        'Topic :: Utilities'
+        'Topic :: Utilities',
+        "Programming Language :: Python :: 3.10",
     ],
     ext_modules = [
         Extension(
@@ -28,4 +29,9 @@ setup(
             include_dirs=['fastlz']
         )
     ]
+    extras_require={
+        "dev": [
+            "pytest",
+        ],
+    },
 )

--- a/test_fastlz.py
+++ b/test_fastlz.py
@@ -1,0 +1,116 @@
+import tarfile
+from glob import iglob
+from io import BytesIO
+from os import path
+from urllib.request import urlopen
+from zipfile import ZipFile
+from pathlib import Path
+
+import pytest
+from pytest import TempPathFactory
+
+from fastlz import compress, decompress
+
+
+@pytest.fixture(scope='session')
+def get_corpus_dir(tmp_path_factory: TempPathFactory) -> Path:
+    download_dir = tmp_path_factory.mktemp("download-unpack")
+    corpus_dir = tmp_path_factory.mktemp("corpus")
+    
+    response = urlopen("https://github.com/MiloszKrajewski/SilesiaCorpus/archive/refs/heads/master.zip")
+    with ZipFile(BytesIO(response.read())) as archive:
+        archive.extractall(download_dir)
+        for i in iglob("*/*.zip", root_dir=download_dir, recursive=True):
+            i_path = path.join(download_dir, i)
+            with ZipFile(i_path) as archive:
+                archive.extractall(path.join(corpus_dir, "silesia"))
+
+    response = urlopen("http://corpus.canterbury.ac.nz/resources/cantrbry.tar.gz")
+    with tarfile.open(fileobj=BytesIO(response.read())) as archive:
+        archive.extractall(path.join(corpus_dir, "canterbury"))
+
+    return corpus_dir
+
+
+@pytest.mark.parametrize("filename", [
+    "silesia/x-ray",
+    "silesia/dickens",
+    "silesia/ooffice",
+    "silesia/sao",
+    "silesia/reymont",
+    "silesia/mr",
+    "silesia/mozilla",
+    "silesia/webster",
+    "silesia/samba",
+    "silesia/osdb",
+    "silesia/nci",
+    "silesia/xml",
+    "canterbury/ptt5",
+    "canterbury/xargs.1",
+    "canterbury/asyoulik.txt",
+    "canterbury/kennedy.xls",
+    "canterbury/plrabn12.txt",
+    "canterbury/grammar.lsp",
+    "canterbury/cp.html",
+    "canterbury/lcet10.txt",
+    "canterbury/alice29.txt",
+    "canterbury/sum",
+    "canterbury/fields.c",
+])
+def test_compress_uncompress_compare(get_corpus_dir: Path, filename: str):
+    """try with some corpuses used in fastlz"""
+    corpus_dir = get_corpus_dir
+    with open(path.join(corpus_dir, filename), "rb") as f:
+        uncompressed = f.read()
+        compressed = compress(uncompressed)
+        uncompressed_2 = decompress(compressed)
+        # print(f"filename: {filename} | sizes: {len(uncompressed)} -> {len(compressed)}")
+        assert uncompressed == uncompressed_2
+
+
+@pytest.mark.parametrize("content", [
+    b"",
+    b"\x00",
+    b"\xFF",
+    b"\x01",
+    b"\x00\x00",
+    b"\xFF\xFF",
+    b"\x01\x01",
+    b"\x00\x00\x00",
+    b"\xFF\xFF\xFF",
+    b"\x01\x01\x01",
+    b"\x00\x00\x00\x00",
+    b"\xFF\xFF\xFF\xFF",
+    b"\x01\x01\x01\x01",
+    b"\x01hello\x00world\x00\x00",
+])
+def test_compress_compress(content: bytes):
+    cnt = 100
+    d = content
+    # compression of compressions
+    for i in range(cnt):
+        d = compress(d)
+    # decompress compression of compressions
+    for i in range(cnt):
+        d = decompress(d)
+    assert d == content
+
+
+@pytest.mark.parametrize("content", [
+    (b"", "00000000"),
+    (b"\x00", "010000000000"),
+    (b"\xFF", "0100000000ff"),
+    (b"\x01", "010000000001"),
+    (b"\x00\x00", "02000000010000"),
+    (b"\xFF\xFF", "0200000001ffff"),
+    (b"\x01\x01", "02000000010101"),
+    (b"\x01hello\x00world\x00\x00", "0e0000000d0168656c6c6f00776f726c640000"),
+])
+def test_version_001(content: bytes):
+    """compare with previous version"""
+    (u_ref, c_ref) = content[0], bytes.fromhex(content[1])
+    c = compress(u_ref)
+    assert c_ref == c
+    u = decompress(c)
+    assert u_ref == u
+


### PR DESCRIPTION
Addresses the error PY_SSIZE_T_CLEAN macro must be defined for '#' formats when using the module in python 3.10.
Updated the c implementation with version 0.5.0.
Added some basic tests